### PR TITLE
Support for object search results

### DIFF
--- a/dev/development_obj.html
+++ b/dev/development_obj.html
@@ -1,0 +1,38 @@
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Autocomplete</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <input class="autocomplete-input">
+  <input class="label">
+
+  <script type="module">
+    import Autocomplete from '/src/index.js'
+
+    const items = ['suggest11', 'suggest12', 'suggest21', 'suggest22']
+    const inputElement = document.querySelector('.autocomplete-input')
+    const anotherInputElement = document.querySelector('.label')
+
+    new Autocomplete(
+      inputElement,
+      (term, onResult) => {
+        const results = [
+          { id: 1, label: "suggest11" },
+          { id: 2, label: "suggest12" },
+          { id: 3, label: "suggest21" },
+          { id: 4, label: "suggest22" }
+        ]
+        onResult(results)
+      },
+      (target) => {
+        inputElement.value = target.dataset.id
+        anotherInputElement.value = target.dataset.label
+      },
+      (item) => `${item.id} ${item.label}`
+    )
+  </script>
+</body>
+</html>

--- a/dev/development_obj.html
+++ b/dev/development_obj.html
@@ -27,9 +27,9 @@
         ]
         onResult(results)
       },
-      (target) => {
-        inputElement.value = target.dataset.id
-        anotherInputElement.value = target.dataset.label
+      (result) => {
+        inputElement.value = result.id
+        anotherInputElement.value = result.label
       },
       (item) => `${item.id} ${item.label}`
     )

--- a/dev/development_str.html
+++ b/dev/development_str.html
@@ -7,6 +7,7 @@
 </head>
 <body>
   <input class="autocomplete-input">
+  <input>
 
   <script type="module">
     import Autocomplete from '/src/index.js'
@@ -20,7 +21,7 @@
         const results = items.filter((item) => item.includes(term))
         onResult(results)
       },
-      (value) => inputElement.value = value
+      (target) => inputElement.value = target.dataset.value
     )
   </script>
 </body>

--- a/dev/development_str.html
+++ b/dev/development_str.html
@@ -21,7 +21,7 @@
         const results = items.filter((item) => item.includes(term))
         onResult(results)
       },
-      (target) => inputElement.value = target.dataset.value
+      (result) => inputElement.value = result.value
     )
   </script>
 </body>

--- a/dev/style.css
+++ b/dev/style.css
@@ -1,4 +1,4 @@
-.autocomplete-input {
+input {
   display: block;
   margin: auto;
   width: 300px;

--- a/src/createResultElement.js
+++ b/src/createResultElement.js
@@ -1,8 +1,8 @@
-export default function createResultElement(item, i) {
+export default function createResultElement(item, i, onRender) {
   const resultElement = document.createElement('li')
   resultElement.classList.add('autocomplete-item')
 
   resultElement.dataset.index = i
-  resultElement.textContent = item
+  resultElement.textContent = onRender(item)
   return resultElement
 }

--- a/src/createResultElement.js
+++ b/src/createResultElement.js
@@ -2,6 +2,14 @@ export default function createResultElement(item, i, onRender) {
   const resultElement = document.createElement('li')
   resultElement.classList.add('autocomplete-item')
 
+  if (typeof item === 'object' && item !== null) {
+    for (const [key, value] of Object.entries(item)) {
+      resultElement.dataset[key] = value
+    }
+  } else {
+    resultElement.dataset.value = item
+  }
+
   resultElement.dataset.index = i
   resultElement.textContent = onRender(item)
   return resultElement

--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,9 @@ export default class Autocomplete {
   #itemContainer
   #model
 
-  constructor(inputElement, onSearch, onSelect, minLength = 3) {
+  constructor(inputElement, onSearch, onSelect, onRender = (item) => item, minLength = 3) {
     this.#onSelect = onSelect
-    this.#itemContainer = new ItemContainer(inputElement)
+    this.#itemContainer = new ItemContainer(inputElement, onRender)
 
     this.#model = new AutocompleteModel(
       (term) => onSearch(term, (results) => (this.#model.items = results)),

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ export default class Autocomplete {
 
   #setEventHandlersToItemsContainer(element) {
     this.#delegate(element, 'mousedown', 'li', ({ delegateTarget }) => {
-      this.#onSelect(delegateTarget.textContent)
+      this.#onSelect(delegateTarget)
       element.hidePopover()
     })
 
@@ -86,7 +86,7 @@ export default class Autocomplete {
       const currentItem = document.querySelector('.autocomplete-item-highlighted')
 
       if (currentItem) {
-        this.#onSelect(currentItem.textContent)
+        this.#onSelect(currentItem)
       }
 
       this.#model.clearItems()

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ export default class Autocomplete {
 
   #setEventHandlersToItemsContainer(element) {
     this.#delegate(element, 'mousedown', 'li', ({ delegateTarget }) => {
-      this.#onSelect(delegateTarget)
+      this.#onSelect(delegateTarget.dataset)
       element.hidePopover()
     })
 
@@ -86,7 +86,7 @@ export default class Autocomplete {
       const currentItem = document.querySelector('.autocomplete-item-highlighted')
 
       if (currentItem) {
-        this.#onSelect(currentItem)
+        this.#onSelect(currentItem.dataset)
       }
 
       this.#model.clearItems()

--- a/src/itemContainer.js
+++ b/src/itemContainer.js
@@ -2,10 +2,12 @@ import createResultElement from './createResultElement.js'
 
 export default class ItemContainer {
   #inputElement
+  #onRender
   #container
 
-  constructor(inputElement) {
+  constructor(inputElement, onRender) {
     this.#inputElement = inputElement
+    this.#onRender = onRender
     this.#container = document.createElement('ul')
     this.#container.setAttribute('popover', 'auto')
     this.#container.classList.add('autocomplete')
@@ -22,7 +24,7 @@ export default class ItemContainer {
   set items(items) {
     if (items.length > 0) {
       this.#container.innerHTML = ''
-      const elements = items.map(createResultElement)
+      const elements = items.map((item, i) => createResultElement(item, i, this.#onRender))
       this.#container.append(...elements)
       this.#moveUnderInputElement()
       this.#container.showPopover()


### PR DESCRIPTION
## 概要
オブジェクトの検索結果に対応する改善を行いました。
これによって、複数のプロパティ内容をレンダリングに含めるなど自由度が上がります。

## 実装内容
- Autocompleteクラスのコンストラクタから候補のレンダリング内容を指定可能に変更
  - https://github.com/yush-nh/autocomplete/pull/2/commits/2f83108fec2545e3ccf8648bba512ad0d1d44f8d
- 文字列のみ期待していた検索結果をオブジェクトにも対応
  - https://github.com/yush-nh/autocomplete/pull/2/commits/c4ad32b4db8053534277c48a64a100177fbec9b0

## 動作確認
### 結果をオブジェクトで渡した場合
dev/development_obj.htmlを使用
次のような動作が可能になります。

https://github.com/user-attachments/assets/7e6b0f75-38c6-49fd-97c7-7709b7f00416

### 結果を文字列で渡した場合
dev/development_str.htmlを使用
通常通りの動きも問題ないです。

https://github.com/user-attachments/assets/32e74dcb-dad1-4ca1-b3c1-3131670115d3