### PR TITLE
Improve popover movement

### DIFF
--- a/dev/development_obj.html
+++ b/dev/development_obj.html
@@ -14,9 +14,11 @@
   </script>
 </head>
 <body>
-  <div class="container">
-    <input class="autocomplete-input">
-    <input class="label">
+  <div class="main-container">
+    <div class="sub-container">
+      <input class="autocomplete-input">
+      <input class="label">
+    </div>
   </div>
 
   <script type="module">

--- a/dev/development_obj.html
+++ b/dev/development_obj.html
@@ -14,8 +14,10 @@
   </script>
 </head>
 <body>
-  <input class="autocomplete-input">
-  <input class="label">
+  <div class="container">
+    <input class="autocomplete-input">
+    <input class="label">
+  </div>
 
   <script type="module">
     import Autocomplete from '/src/index.js'

--- a/dev/development_str.html
+++ b/dev/development_str.html
@@ -14,8 +14,10 @@
   </script>
 </head>
 <body>
-  <input class="autocomplete-input">
-  <input>
+  <div class="container">
+    <input class="autocomplete-input">
+    <input>
+  </div>
 
   <script type="module">
     import Autocomplete from '/src/index.js'

--- a/dev/development_str.html
+++ b/dev/development_str.html
@@ -14,9 +14,10 @@
   </script>
 </head>
 <body>
-  <div class="container">
-    <input class="autocomplete-input">
-    <input>
+  <div class="main-container">
+    <div class="sub-container">
+      <input class="autocomplete-input">
+    </div>
   </div>
 
   <script type="module">

--- a/dev/style.css
+++ b/dev/style.css
@@ -1,9 +1,18 @@
-.container {
+.main-container {
   width: 800px;
-  height: 500px;
+  height: 600px;
   border: 1px solid #ccc;
   resize: both;
   overflow: auto;
+}
+
+.sub-container {
+  width: 600px;
+  height: 400px;
+  border: 1px solid #ccc;
+  resize: both;
+  overflow: auto;
+  margin: auto;
 }
 
 input {

--- a/dev/style.css
+++ b/dev/style.css
@@ -1,4 +1,13 @@
+.container {
+  width: 800px;
+  height: 500px;
+  border: 1px solid #ccc;
+  resize: both;
+  overflow: auto;
+}
+
 input {
+  width: 100%;
   display: block;
   margin: auto;
   width: 300px;

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ export default class Autocomplete {
 
     this.#setEventHandlersToInput(inputElement)
     this.#setEventHandlersToItemsContainer(this.#itemContainer.element)
+    this.#setGlobalEventHandlers()
   }
 
   #setEventHandlersToInput(element) {
@@ -36,7 +37,6 @@ export default class Autocomplete {
     element.addEventListener('input', ({ target }) => handleInput(target.value))
     element.addEventListener('keydown', (event) => this.#handleKeydown(event))
     element.addEventListener('keyup', (event) => this.#handleKeyup(event))
-    element.addEventListener('blur', () => this.#model.clearItems())
   }
 
   #setEventHandlersToItemsContainer(element) {
@@ -52,6 +52,20 @@ export default class Autocomplete {
     this.#delegate(element, 'mouseout', 'li', () => {
       this.#model.clearHighlight()
     })
+  }
+
+  #setGlobalEventHandlers() {
+    // Initially intended that itemContainer follows the resizing of the parent element,
+    // but it could not handle recurrent parent element resizing.
+    // As a workaround, the itemContainer is hidden when interacting outside it or when the window is resized.
+
+    document.addEventListener('mousedown', ({ target }) => {
+      if (!this.#itemContainer.element.contains(target)) {
+        this.#model.clearItems()
+      }
+    })
+
+    window.addEventListener('resize', this.#model.clearItems())
   }
 
   #delegate(element, event, selector, callback) {

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ export default class Autocomplete {
     element.addEventListener('input', ({ target }) => handleInput(target.value))
     element.addEventListener('keydown', (event) => this.#handleKeydown(event))
     element.addEventListener('keyup', (event) => this.#handleKeyup(event))
+    element.addEventListener('blur', () => this.#model.clearItems())
   }
 
   #setEventHandlersToItemsContainer(element) {

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export default class Autocomplete {
 
     this.#setEventHandlersToInput(inputElement)
     this.#setEventHandlersToItemsContainer(this.#itemContainer.element)
-    this.#setItemContainerHideHandlers()
+    this.#setEventHandlersToHideItemContainer()
   }
 
   #setEventHandlersToInput(element) {
@@ -54,7 +54,7 @@ export default class Autocomplete {
     })
   }
 
-  #setItemContainerHideHandlers() {
+  #setEventHandlersToHideItemContainer() {
     // Initially intended that itemContainer follows the resizing of the parent element,
     // but it could not handle recurrent parent element resizing.
     // As a workaround, the itemContainer is hidden when interacting outside it or when the window is resized.

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export default class Autocomplete {
 
     this.#setEventHandlersToInput(inputElement)
     this.#setEventHandlersToItemsContainer(this.#itemContainer.element)
-    this.#setGlobalEventHandlers()
+    this.#setItemContainerHideHandlers()
   }
 
   #setEventHandlersToInput(element) {
@@ -54,7 +54,7 @@ export default class Autocomplete {
     })
   }
 
-  #setGlobalEventHandlers() {
+  #setItemContainerHideHandlers() {
     // Initially intended that itemContainer follows the resizing of the parent element,
     // but it could not handle recurrent parent element resizing.
     // As a workaround, the itemContainer is hidden when interacting outside it or when the window is resized.

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ export default class Autocomplete {
       }
     })
 
-    window.addEventListener('resize', this.#model.clearItems())
+    window.addEventListener('resize', () => this.#model.clearItems())
   }
 
   #delegate(element, event, selector, callback) {

--- a/src/itemContainer.js
+++ b/src/itemContainer.js
@@ -4,6 +4,7 @@ export default class ItemContainer {
   #inputElement
   #onRender
   #container
+  #resizeObserver
 
   constructor(inputElement, onRender) {
     this.#inputElement = inputElement
@@ -15,6 +16,8 @@ export default class ItemContainer {
     inputElement.parentElement.appendChild(this.#container)
 
     window.addEventListener('resize', this.#moveUnderInputElement.bind(this))
+    this.#resizeObserver = new ResizeObserver(this.#moveUnderInputElement.bind(this))
+    this.#resizeObserver.observe(inputElement.parentElement)
   }
 
   get element() {

--- a/src/itemContainer.js
+++ b/src/itemContainer.js
@@ -4,7 +4,6 @@ export default class ItemContainer {
   #inputElement
   #onRender
   #container
-  #resizeObserver
 
   constructor(inputElement, onRender) {
     this.#inputElement = inputElement
@@ -14,10 +13,6 @@ export default class ItemContainer {
     this.#container.classList.add('autocomplete')
     this.#container.style.margin = 0 // Clear popover default style.
     inputElement.parentElement.appendChild(this.#container)
-
-    window.addEventListener('resize', this.#moveUnderInputElement.bind(this))
-    this.#resizeObserver = new ResizeObserver(this.#moveUnderInputElement.bind(this))
-    this.#resizeObserver.observe(inputElement.parentElement)
   }
 
   get element() {

--- a/src/itemContainer.js
+++ b/src/itemContainer.js
@@ -10,7 +10,7 @@ export default class ItemContainer {
     this.#inputElement = inputElement
     this.#onRender = onRender
     this.#container = document.createElement('ul')
-    this.#container.setAttribute('popover', 'auto')
+    this.#container.setAttribute('popover', 'manual')
     this.#container.classList.add('autocomplete')
     this.#container.style.margin = 0 // Clear popover default style.
     inputElement.parentElement.appendChild(this.#container)


### PR DESCRIPTION
## 概要
画面に表示される候補の動きに改善を行いました。

## 行ったこと
- 親要素のリサイズに追従するように変更
- input要素のフォーカスが外れた場合に候補を消すイベントを追加
- PopoverAPIの[light dismiss](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API/Using#auto_state_and_light_dismiss)機能を無効化

## 動作確認
### 親要素のリサイズに追従
修正前はwindowリサイズのみ監視していました。親要素のサイズを変更した場合、候補は移動せずズレが生じていました。
これを親要素のリサイズに追従するように変更することで解決しました。

また、親要素のリサイズのみ監視するとwindowリサイズ時にズレが生じたので、windowと親要素の両方を監視する形にしました。

#### 改善前

https://github.com/user-attachments/assets/8fbafa2b-a8b6-4488-946f-09419d226a0b

#### 改善後

https://github.com/user-attachments/assets/c4e3b802-b3ef-4724-a56a-885ca537cdb3

### フォーカスイベントについて
要素のドラッグ移動時に候補が残ってしまう問題がありました。

ドラッグ開始時には候補が消えるのが自然だと思います。この問題の対応としてinput要素のフォーカスが外れた場合に候補を消すイベントを追加しました。

#### 改善前

https://github.com/user-attachments/assets/06a5bf38-b853-45ec-8f7d-11d3d1c8209a

#### 改善後

https://github.com/user-attachments/assets/030fa050-0fa3-485d-a6d5-a7ace5ee59c5

### popoverのlight dismiss機能について
popoverAPIのpopover要素は、値をauto/manualで選択可能です。
autoにすると、PopoverAPIのlight dismiss機能というpopover以外をクリックするとpopoverを閉じる機能が有効化されます。

これによって、CSSでのリサイズのようなフォーカス状態を維持する場合でも候補が消えてしまう問題がありました。
これをpopover属性の値を`manual`にすることで解決しました。

#### 改善前

https://github.com/user-attachments/assets/d8965866-c22f-4499-a345-c409733bf2f3

#### 改善後

https://github.com/user-attachments/assets/375d8243-0c85-41dd-a168-6fdd8b9c616a