### PR TITLE
Rename package

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ minLength: 4
 This library does not provide CSS.  
 However, each generated HTML element has a predefined class attribute. To apply styles, you can specify the following classes in your CSS.
 
-| Class Attribute                  | Description                              |
-|----------------------------------|------------------------------------------|
-| `.autocomplete`                  | The main container for the autocomplete |
-| `.autocomplete-item`             | An individual suggestion item           |
-| `.autocomplete-item-highlighted` | The highlighted suggestion item         |
+| Class Attribute                         | Description                             |
+|-----------------------------------------|-----------------------------------------|
+| `popover-autocomplete-container`        | The main container for the autocomplete |
+| `popover-autocomplete-item`             | An individual suggestion item           |
+| `popover-autocomplete-item-highlighted` | The highlighted suggestion item         |
 
 
 # Run Tests

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Import autocomplete library to your project
 or
 ```js
 // ES6 modules
-import Autocomplete from '@ysh-nh/autocomplete'
+import Autocomplete from 'popover-autocomplete'
 ```
 Prepare search data.   
 This supports an array of strings or an array of objects.
@@ -128,7 +128,7 @@ cd tests/package-test-project
 
 Install package.
 ```
-npm install ../../ysh-nh-autocomplete-1.0.0.tgz
+npm install ../../popover-autocomplete-[version].tgz
 ```
 
 ### 3. Build

--- a/dev/style.css
+++ b/dev/style.css
@@ -38,7 +38,7 @@ input {
   box-shadow: 0 0 6px rgba(0, 120, 215, 0.5);
 }
 
-.autocomplete {
+.popover-autocomplete-container {
   position: absolute;
   top: 100%;
   left: 0;
@@ -53,7 +53,7 @@ input {
   list-style: none;
 }
 
-.autocomplete-item {
+.popover-autocomplete-item {
   padding: 10px 15px;
   font-size: 14px;
   font-family: Arial, sans-serif;
@@ -61,6 +61,6 @@ input {
   cursor: pointer;
 }
 
-.autocomplete-item-highlighted {
+.popover-autocomplete-item-highlighted {
   background-color: #f0f0f0;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@ysh_nh/autocomplete",
+  "name": "popover-autocomplete",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ysh_nh/autocomplete",
+      "name": "popover-autocomplete",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ysh_nh/autocomplete",
+  "name": "popover-autocomplete",
   "version": "1.0.0",
   "description": "An autocomplete library supporting top-layer display using the Popover API.",
   "main": "src/index.js",
@@ -13,12 +13,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/yush-nh/autocomplete.git"
+    "url": "git+https://github.com/yush-nh/popover-autocomplete.git"
   },
   "bugs": {
-    "url": "https://github.com/yush-nh/autocomplete/issues"
+    "url": "https://github.com/yush-nh/popover-autocomplete/issues"
   },
-  "homepage": "https://github.com/yush-nh/autocomplete/blob/main/README.md",
+  "homepage": "https://github.com/yush-nh/popover-autocomplete/blob/main/README.md",
   "keywords": [
     "autocomplete",
     "popover",

--- a/src/createResultElement.js
+++ b/src/createResultElement.js
@@ -1,6 +1,6 @@
 export default function createResultElement(item, i, onRender) {
   const resultElement = document.createElement('li')
-  resultElement.classList.add('autocomplete-item')
+  resultElement.classList.add('popover-autocomplete-item')
 
   if (typeof item === 'object' && item !== null) {
     for (const [key, value] of Object.entries(item)) {

--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,7 @@ export default class Autocomplete {
     if (event.key === 'Enter' && this.#model.hasItems) {
       event.stopPropagation()
 
-      const currentItem = document.querySelector('.autocomplete-item-highlighted')
+      const currentItem = document.querySelector('.popover-autocomplete-item-highlighted')
 
       if (currentItem) {
         this.#onSelect(currentItem.dataset)

--- a/src/itemContainer.js
+++ b/src/itemContainer.js
@@ -10,7 +10,7 @@ export default class ItemContainer {
     this.#onRender = onRender
     this.#container = document.createElement('ul')
     this.#container.setAttribute('popover', 'manual')
-    this.#container.classList.add('autocomplete')
+    this.#container.classList.add('popover-autocomplete-container')
     this.#container.style.margin = 0 // Clear popover default style.
     inputElement.parentElement.appendChild(this.#container)
   }
@@ -37,7 +37,7 @@ export default class ItemContainer {
     const target = this.#container.querySelector(`li:nth-child(${index + 1})`)
 
     if (target) {
-      target.classList.add('autocomplete-item-highlighted')
+      target.classList.add('popover-autocomplete-item-highlighted')
     }
   }
 
@@ -52,10 +52,10 @@ export default class ItemContainer {
   }
 
   #unhighlight() {
-    const target = this.#container.querySelector('.autocomplete-item-highlighted')
+    const target = this.#container.querySelector('.popover-autocomplete-item-highlighted')
 
     if (target) {
-      target.classList.remove('autocomplete-item-highlighted')
+      target.classList.remove('popover-autocomplete-item-highlighted')
     }
   }
 }

--- a/tests/package-test-project/app.js
+++ b/tests/package-test-project/app.js
@@ -1,4 +1,4 @@
-import Autocomplete from "@ysh-nh/autocomplete"
+import Autocomplete from "popover-autocomplete"
 
 const items = ['suggest11', 'suggest12', 'suggest21', 'suggest22']
 const inputElement = document.querySelector('.autocomplete-input')

--- a/tests/package-test-project/style.css
+++ b/tests/package-test-project/style.css
@@ -38,7 +38,7 @@ input {
   box-shadow: 0 0 6px rgba(0, 120, 215, 0.5);
 }
 
-.autocomplete {
+.popover-autocomplete-container {
   position: absolute;
   top: 100%;
   left: 0;
@@ -53,7 +53,7 @@ input {
   list-style: none;
 }
 
-.autocomplete-item {
+.popover-autocomplete-item {
   padding: 10px 15px;
   font-size: 14px;
   font-family: Arial, sans-serif;
@@ -61,6 +61,6 @@ input {
   cursor: pointer;
 }
 
-.autocomplete-item-highlighted {
+.popover-autocomplete-item-highlighted {
   background-color: #f0f0f0;
 }

--- a/tests/test_obj_data.spec.js
+++ b/tests/test_obj_data.spec.js
@@ -9,7 +9,7 @@ test.describe('when data is array of objects', () => {
     const input = page.locator('.autocomplete-input')
     await input.fill('sug')
 
-    const suggestion = page.locator('.autocomplete li', { hasText: 'suggest11' })
+    const suggestion = page.locator('.popover-autocomplete-container li', { hasText: 'suggest11' })
     await suggestion.click()
 
     const anotherInput = page.locator('.another-input')

--- a/tests/test_option.spec.js
+++ b/tests/test_option.spec.js
@@ -9,7 +9,7 @@ test.describe('when specifying minLength and input is less than minLength', () =
     const input = page.locator('.autocomplete-input')
     await input.fill('sug')
 
-    const suggestions = page.locator('.autocomplete li')
+    const suggestions = page.locator('.popover-autocomplete-container li')
     await expect(suggestions).toHaveCount(0)
   })
 })
@@ -19,7 +19,7 @@ test.describe('when specifying onRender', () => {
     const input = page.locator('.autocomplete-input')
     await input.fill('sugg')
 
-    const firstSuggestion = page.locator('.autocomplete li').first()
+    const firstSuggestion = page.locator('.popover-autocomplete-container li').first()
     const suggestionText = await firstSuggestion.textContent()
 
     await expect(suggestionText).toBe('result: suggest11')

--- a/tests/test_str_data.spec.js
+++ b/tests/test_str_data.spec.js
@@ -9,10 +9,10 @@ test.describe('when input value matched', () => {
     const input = page.locator('.autocomplete-input')
     await input.fill('suggest2')
 
-    const suggestionList = page.locator('.autocomplete')
+    const suggestionList = page.locator('.popover-autocomplete-container')
     await expect(suggestionList).toBeVisible()
 
-    const suggestions = page.locator('.autocomplete li')
+    const suggestions = page.locator('.popover-autocomplete-container li')
     await expect(suggestions).toHaveCount(2)
   })
 })
@@ -22,7 +22,7 @@ test.describe('when input value does not matched', () => {
     const input = page.locator('.autocomplete-input')
     await input.fill('abc')
 
-    const suggestionList = page.locator('.autocomplete')
+    const suggestionList = page.locator('.popover-autocomplete-container')
     await expect(suggestionList).toBeHidden()
   })
 })
@@ -32,7 +32,7 @@ test.describe('when not specifying minLength and input is less than 3 characters
     const input = page.locator('.autocomplete-input')
     await input.fill('su')
 
-    const suggestions = page.locator('.autocomplete li')
+    const suggestions = page.locator('.popover-autocomplete-container li')
     await expect(suggestions).toHaveCount(0)
   })
 })
@@ -43,10 +43,10 @@ test.describe('when suggestion hovered', () => {
     const input = page.locator('.autocomplete-input')
     await input.fill('sug')
 
-    const suggestion = page.locator('.autocomplete li', { hasText: 'suggest11' })
+    const suggestion = page.locator('.popover-autocomplete-container li', { hasText: 'suggest11' })
     await suggestion.hover()
 
-    await expect(suggestion).toHaveClass(/autocomplete-item-highlighted/)
+    await expect(suggestion).toHaveClass(/popover-autocomplete-item-highlighted/)
   })
 })
 
@@ -55,13 +55,13 @@ test.describe('when suggestion unhovered', () => {
     const input = page.locator('.autocomplete-input')
     await input.fill('sug')
 
-    const suggestion = page.locator('.autocomplete li', { hasText: 'suggest11' })
+    const suggestion = page.locator('.popover-autocomplete-container li', { hasText: 'suggest11' })
     await suggestion.hover()
-    await expect(suggestion).toHaveClass(/autocomplete-item-highlighted/)
+    await expect(suggestion).toHaveClass(/popover-autocomplete-item-highlighted/)
 
     const body = page.locator('body')
     await body.hover()
-    await expect(suggestion).not.toHaveClass(/autocomplete-item-highlighted/)
+    await expect(suggestion).not.toHaveClass(/popover-autocomplete-item-highlighted/)
   })
 })
 
@@ -70,7 +70,7 @@ test.describe('when suggestion clicked', () => {
     const input = page.locator('.autocomplete-input')
     await input.fill('sug')
 
-    const suggestion = page.locator('.autocomplete li', { hasText: 'suggest11' })
+    const suggestion = page.locator('.popover-autocomplete-container li', { hasText: 'suggest11' })
     await suggestion.click()
 
     await expect(input).toHaveValue('suggest11')
@@ -82,7 +82,7 @@ test.describe('when interacted outside of suggestions', () => {
     const input = page.locator('.autocomplete-input')
     await input.fill('sug')
 
-    const suggestionList = page.locator('.autocomplete')
+    const suggestionList = page.locator('.popover-autocomplete-container')
     await expect(suggestionList).toBeVisible()
 
     await page.click('body')
@@ -95,13 +95,13 @@ test.describe('when ArrowDown key pressed', () => {
     const input = page.locator('.autocomplete-input')
     await input.fill('sug')
 
-    const firstSuggestion = page.locator('.autocomplete li').first()
-    await expect(firstSuggestion).not.toHaveClass(/autocomplete-item-highlighted/)
+    const firstSuggestion = page.locator('.popover-autocomplete-container li').first()
+    await expect(firstSuggestion).not.toHaveClass(/popover-autocomplete-item-highlighted/)
 
     await input.focus()
     await page.keyboard.press('ArrowDown')
 
-    await expect(firstSuggestion).toHaveClass(/autocomplete-item-highlighted/)
+    await expect(firstSuggestion).toHaveClass(/popover-autocomplete-item-highlighted/)
   })
 })
 
@@ -110,12 +110,12 @@ test.describe('when ArrowUp key pressed', () => {
     const input = page.locator('.autocomplete-input')
     await input.fill('sug')
 
-    const lastSuggestion = page.locator('.autocomplete li').last()
-    await expect(lastSuggestion).not.toHaveClass(/autocomplete-item-highlighted/)
+    const lastSuggestion = page.locator('.popover-autocomplete-container li').last()
+    await expect(lastSuggestion).not.toHaveClass(/popover-autocomplete-item-highlighted/)
 
     await input.focus()
     await page.keyboard.press('ArrowUp')
-    await expect(lastSuggestion).toHaveClass(/autocomplete-item-highlighted/)
+    await expect(lastSuggestion).toHaveClass(/popover-autocomplete-item-highlighted/)
   })
 })
 
@@ -124,12 +124,12 @@ test.describe('when Tab key pressed', () => {
     const input = page.locator('.autocomplete-input')
     await input.fill('sug')
 
-    const firstSuggestion = page.locator('.autocomplete li').first()
-    await expect(firstSuggestion).not.toHaveClass(/autocomplete-item-highlighted/)
+    const firstSuggestion = page.locator('.popover-autocomplete-container li').first()
+    await expect(firstSuggestion).not.toHaveClass(/popover-autocomplete-item-highlighted/)
 
     await input.focus()
     await page.keyboard.press('Tab')
-    await expect(firstSuggestion).toHaveClass(/autocomplete-item-highlighted/)
+    await expect(firstSuggestion).toHaveClass(/popover-autocomplete-item-highlighted/)
   })
 })
 
@@ -138,13 +138,13 @@ test.describe('when Shift+Tab key pressed', () => {
     const input = page.locator('.autocomplete-input')
     await input.fill('sug')
 
-    const lastSuggestion = page.locator('.autocomplete li').last()
-    await expect(lastSuggestion).not.toHaveClass(/autocomplete-item-highlighted/)
+    const lastSuggestion = page.locator('.popover-autocomplete-container li').last()
+    await expect(lastSuggestion).not.toHaveClass(/popover-autocomplete-item-highlighted/)
 
     await input.focus()
     await page.keyboard.down('Shift')
     await page.keyboard.press('Tab')
-    await expect(lastSuggestion).toHaveClass(/autocomplete-item-highlighted/)
+    await expect(lastSuggestion).toHaveClass(/popover-autocomplete-item-highlighted/)
   })
 })
 
@@ -153,12 +153,12 @@ test.describe('when Enter key pressed while a suggestion highlighted', () => {
     const input = page.locator('.autocomplete-input')
     await input.fill('sug')
 
-    const firstSuggestion = page.locator('.autocomplete li').first()
-    await expect(firstSuggestion).not.toHaveClass(/autocomplete-item-highlighted/)
+    const firstSuggestion = page.locator('.popover-autocomplete-container li').first()
+    await expect(firstSuggestion).not.toHaveClass(/popover-autocomplete-item-highlighted/)
 
     await input.focus()
     await page.keyboard.press('ArrowDown')
-    await expect(firstSuggestion).toHaveClass(/autocomplete-item-highlighted/)
+    await expect(firstSuggestion).toHaveClass(/popover-autocomplete-item-highlighted/)
 
     const suggestionText = await firstSuggestion.textContent()
     await expect(suggestionText).toBe('suggest11')
@@ -172,7 +172,7 @@ test.describe('when Escape key pressed', () => {
     const input = page.locator('.autocomplete-input')
     await input.fill('sug')
 
-    const suggestionList = page.locator('.autocomplete')
+    const suggestionList = page.locator('.popover-autocomplete-container')
     await expect(suggestionList).toBeVisible()
 
     await page.keyboard.press('Escape')


### PR DESCRIPTION
## 概要
ライブラリ名を変更し、css class名の調整などを行いました。

## 作業内容
- ライブラリ名の変更
- githubリポジトリ名変更によるpackage.jsonの修正
- css class名の変更
- READMEの更新

## 動作確認
### 自動テスト
自動テストが全て通ることを確認しました。
```
➜  autocomplete git:(misc/rename_package) npm run test

> popover-autocomplete@1.0.0 test
> playwright test


Running 16 tests using 3 workers

  ✓  1 tests/test_obj_data.spec.js:8:3 › when data is array of objects › it should be able to get values from result with same properties (1.2s)
  ✓  2 tests/test_option.spec.js:8:3 › when specifying minLength and input is less than minLength › it should not display suggestions (328ms)
  ✓  3 tests/test_str_data.spec.js:8:3 › when input value matched › it should display suggestions (690ms)
  ✓  4 tests/test_option.spec.js:18:3 › when specifying onRender › it should display with specified format (884ms)
  ✓  5 tests/test_str_data.spec.js:21:3 › when input value does not matched › it should not display suggestions (99ms)
  ✓  6 tests/test_str_data.spec.js:31:3 › when not specifying minLength and input is less than 3 characters › it should not display suggestions (87ms)
  ✓  7 tests/test_str_data.spec.js:42:3 › when suggestion hovered › it should highlighted (922ms)
  ✓  8 tests/test_str_data.spec.js:54:3 › when suggestion unhovered › it should unhighlighted (973ms)
  ✓  9 tests/test_str_data.spec.js:69:3 › when suggestion clicked › it should applied in the input (931ms)
  ✓  10 tests/test_str_data.spec.js:81:3 › when interacted outside of suggestions › it should hide suggestions (501ms)
  ✓  11 tests/test_str_data.spec.js:94:3 › when ArrowDown key pressed › it highlight one suggestion below (484ms)
  ✓  12 tests/test_str_data.spec.js:109:3 › when ArrowUp key pressed › it highlight one suggestion above (467ms)
  ✓  13 tests/test_str_data.spec.js:123:3 › when Tab key pressed › it highlight one suggestion below (483ms)
  ✓  14 tests/test_str_data.spec.js:137:3 › when Shift+Tab key pressed › it highlight one suggestion above (473ms)
  ✓  15 tests/test_str_data.spec.js:152:3 › when Enter key pressed while a suggestion highlighted › it should applied in the input (477ms)
  ✓  16 tests/test_str_data.spec.js:171:3 › when Escape key pressed › it should hide suggestions (495ms)

  16 passed (7.7s)
```

### 手動テスト
- 開発用HTMLを用いてスタイルや動作に問題がないか確認し、問題ありませんでした。
- npm経由で動作が問題ないか確認し、問題ありませんでした。