### PR TITLE
Prevent default action on arrowkey

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,10 +82,12 @@ export default class Autocomplete {
 
     switch (event.key) {
       case 'ArrowDown':
+        event.preventDefault()
         this.#model.moveHighlightIndexNext()
         break
 
       case 'ArrowUp':
+        event.preventDefault()
         this.#model.moveHighlightIndexPrevious()
         break
 


### PR DESCRIPTION
## 概要
上下キーのデフォルト動作が残っていたため、無効化しました。

## 修正前
入力欄のテキストカーソルが前後に動いてしまっています。

https://github.com/user-attachments/assets/7c9d9ce9-6902-4c43-9969-0ea56f4b2de3

## 修正後
入力欄のテキストカーソルが動かなくなりました。

https://github.com/user-attachments/assets/62070caa-6d05-490c-b6d0-346c545cadb4